### PR TITLE
Byte array support

### DIFF
--- a/MsgPack/MsgPackDeserializer.cs
+++ b/MsgPack/MsgPackDeserializer.cs
@@ -74,6 +74,16 @@ namespace CitizenFX.MsgPack
 			return v;
 		}
 
+		internal unsafe byte[] ReadByteArray(uint size)
+		{
+		    byte* ptr = AdvancePointer(size);
+
+		    byte[] array = new byte[size];
+		    Marshal.Copy((IntPtr)ptr, array, 0, (int)size);
+
+		    return array;
+		}
+
 		internal MsgPackCode ReadType() => (MsgPackCode)ReadByte();
 
 		internal byte ReadUInt8() => ReadByte();

--- a/MsgPack/MsgPackDeserializerConvert.cs
+++ b/MsgPack/MsgPackDeserializerConvert.cs
@@ -205,6 +205,42 @@ namespace CitizenFX.MsgPack
 				SkipObject();
 		}
 
+		internal byte[] ConvertMsgPackedTypesToByteArray(uint size)
+		{
+		    byte[] array = new byte[size];
+
+		    for (uint i = 0; i < size; ++i)
+			array[i] = (byte)DeserializeAsUInt32();
+
+		    return array;
+		}
+
+		public byte[] DeserializeAsByteArray()
+		{
+		    MsgPackCode type = (MsgPackCode)ReadByte();
+		    if (type >= MsgPackCode.FixArrayMin && type <= MsgPackCode.FixArrayMax)
+			return ConvertMsgPackedTypesToByteArray((byte)type % 16u);
+
+		    switch (type)
+		    {
+			case MsgPackCode.Bin8:
+			    return ReadByteArray(ReadUInt8());
+			case MsgPackCode.Bin16:
+			    return ReadByteArray(ReadUInt16());
+			case MsgPackCode.Bin32:
+			    return ReadByteArray(ReadUInt32());
+			case MsgPackCode.Array16:
+			    return ConvertMsgPackedTypesToByteArray(ReadUInt16());
+			case MsgPackCode.Array32:
+			    return ConvertMsgPackedTypesToByteArray(ReadUInt16());
+		    }
+
+		    SkipObject(type);
+		    throw new InvalidCastException(
+			$"MsgPack type {type} could not be deserialized into type {typeof(byte[])}"
+		    );
+		}
+
 		public unsafe bool DeserializeAsBool()
 		{
 			MsgPackCode type = ReadType();

--- a/MsgPack/MsgPackSerializer.cs
+++ b/MsgPack/MsgPackSerializer.cs
@@ -90,6 +90,22 @@ namespace CitizenFX.MsgPack
 				Write(MsgPackCode.UInt8, v);
 		}
 
+		public void Serialize(byte[] v)
+		{
+		    uint size = (uint)v.Length;
+
+		    if (size <= byte.MaxValue)
+			Write(MsgPackCode.Bin8, unchecked((byte)size));
+		    else if (size <= ushort.MaxValue)
+			WriteBigEndian(MsgPackCode.Bin16, unchecked((ushort)size));
+		    else
+			WriteBigEndian(MsgPackCode.Bin32, size);
+
+		    EnsureCapacity(size);
+		    Array.Copy(v, 0, m_buffer, (int)m_position, size);
+		    m_position += size;
+		}
+
 		public void Serialize(short v)
 		{
 			if (v < 0)


### PR DESCRIPTION
### Goal of this PR
Add support for FiveM's custom MsgPack handling of byte arrays.

### How This PR Achieves the Goal
Implemented the missing serializer and deserializer for byte arrays.

### Issues Fixed
Fixes [FiveM Issue #2571](https://github.com/citizenfx/fivem/issues/2571)