### PR TITLE
Improve MsgPack Serialization: Delegate Support, List Fixes, and Byte Array Handling

### DIFF
--- a/MsgPack/Formatters/ArrayFormatter.cs
+++ b/MsgPack/Formatters/ArrayFormatter.cs
@@ -13,7 +13,7 @@ namespace CitizenFX.MsgPack.Formatters
 		{
 			MethodInfo methodSerialize, methodDeserialize, methodObjectSerialize;
 
-			string name = $"ArrayFormatter<{typeArray.FullName}>";
+			string name = $"ArrayFormatter[{typeArray.FullName}]";
 			Type buildType = MsgPackRegistry.m_moduleBuilder.GetType(name);
 
 			if (buildType == null)

--- a/MsgPack/Formatters/ArrayFormatter.cs
+++ b/MsgPack/Formatters/ArrayFormatter.cs
@@ -7,228 +7,235 @@ using System.Runtime.InteropServices;
 
 namespace CitizenFX.MsgPack.Formatters
 {
-	internal static class ArrayFormatter
-	{
-		public static Tuple<Serializer, MethodInfo> Build(Type type, Type typeArray)
-		{
-			MethodInfo methodSerialize, methodDeserialize, methodObjectSerialize;
+    internal static class ArrayFormatter
+    {
+        public static Tuple<Serializer, MethodInfo> Build(Type type, Type typeArray)
+        {
+            MethodInfo methodSerialize, methodDeserialize, methodObjectSerialize;
 
-			string name = $"ArrayFormatter[{typeArray.FullName}]";
-			Type buildType = MsgPackRegistry.m_moduleBuilder.GetType(name);
+            string name = $"ArrayFormatter_{typeArray.FullName}";
+            Type buildType = MsgPackRegistry.m_moduleBuilder.GetType(name);
 
-			if (buildType == null)
-			{
-				TypeBuilder typeBuilder = MsgPackRegistry.m_moduleBuilder.DefineType(name);
+            if (buildType == null)
+            {
+                TypeBuilder typeBuilder = MsgPackRegistry.m_moduleBuilder.DefineType(name);
 
-				methodSerialize = BuildSerializer(type, typeArray, typeBuilder);
-				BuildDeserializer(type, typeArray, typeBuilder);
-				BuildObjectSerializer(typeArray, methodSerialize, typeBuilder);
+                methodSerialize = BuildSerializer(type, typeArray, typeBuilder);
+                BuildDeserializer(type, typeArray, typeBuilder);
+                BuildObjectSerializer(typeArray, methodSerialize, typeBuilder);
 
-				buildType = typeBuilder.CreateType();
-			}
+                buildType = typeBuilder.CreateType();
+            }
 
-			methodSerialize = buildType.GetMethod("Serialize", new[] { typeof(MsgPackSerializer), type });
-			methodDeserialize = buildType.GetMethod("Deserialize");
-			methodObjectSerialize = buildType.GetMethod("Serialize", new[] { typeof(MsgPackSerializer), typeof(object) });
+            methodSerialize = buildType.GetMethod("Serialize", new[] { typeof(MsgPackSerializer), type });
+            methodDeserialize = buildType.GetMethod("Deserialize");
+            methodObjectSerialize = buildType.GetMethod("Serialize", new[] { typeof(MsgPackSerializer), typeof(object) });
 
-			Serializer serializeMethods = new Serializer(methodSerialize, methodObjectSerialize);
+            Serializer serializeMethods = new Serializer(methodSerialize, methodObjectSerialize);
 
-			MsgPackRegistry.RegisterSerializer(typeArray, serializeMethods);
-			MsgPackRegistry.RegisterDeserializer(typeArray, methodDeserialize);
+            MsgPackRegistry.RegisterSerializer(typeArray, serializeMethods);
+            MsgPackRegistry.RegisterDeserializer(typeArray, methodDeserialize);
 
-			return new Tuple<Serializer, MethodInfo>(serializeMethods, methodDeserialize);
-		}
+            return new Tuple<Serializer, MethodInfo>(serializeMethods, methodDeserialize);
+        }
 
-		/// <summary>
-		/// Simply unpacks and calls <paramref name="methodSerialize"/>
-		/// </summary>
-		/// <param name="typeArray">Type we're serializing</param>
-		/// <param name="methodSerialize">Method to call once the object is unpacked</param>
-		/// <param name="typeBuilder">Building type to add this method to</param>
-		/// <returns></returns>
-		private static MethodInfo BuildObjectSerializer(Type typeArray, MethodInfo methodSerialize, TypeBuilder typeBuilder)
-		{
-			MethodBuilder methodSerializeObject = typeBuilder.DefineMethod("Serialize",
-				MethodAttributes.Public | MethodAttributes.Static,
-				typeof(void), new[] { typeof(MsgPackSerializer), typeof(object) });
+        /// <summary>
+        /// Simply unpacks and calls <paramref name="methodSerialize"/>
+        /// </summary>
+        /// <param name="typeArray">Type we're serializing</param>
+        /// <param name="methodSerialize">Method to call once the object is unpacked</param>
+        /// <param name="typeBuilder">Building type to add this method to</param>
+        /// <returns></returns>
+        private static MethodInfo BuildObjectSerializer(Type typeArray, MethodInfo methodSerialize, TypeBuilder typeBuilder)
+        {
+            MethodBuilder methodSerializeObject = typeBuilder.DefineMethod("Serialize",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(void), new[] { typeof(MsgPackSerializer), typeof(object) });
 
-			var g = methodSerializeObject.GetILGenerator();
-			g.Emit(OpCodes.Ldarg_0);
-			g.Emit(OpCodes.Ldarg_1);
-			g.Emit(OpCodes.Unbox_Any, typeArray);
-			g.EmitCall(OpCodes.Call, methodSerialize, null);
-			g.Emit(OpCodes.Ret);
+            var g = methodSerializeObject.GetILGenerator();
+            g.Emit(OpCodes.Ldarg_0);
+            g.Emit(OpCodes.Ldarg_1);
+            g.Emit(OpCodes.Unbox_Any, typeArray);
+            g.EmitCall(OpCodes.Call, methodSerialize, null);
+            g.Emit(OpCodes.Ret);
 
-			return methodSerializeObject;
-		}
+            return methodSerializeObject;
+        }
 
-		private static MethodInfo BuildSerializer(Type type, Type typeArray, TypeBuilder typeBuilder)
-		{
-			MethodBuilder methodSerialize = typeBuilder.DefineMethod("Serialize",
-				MethodAttributes.Public | MethodAttributes.Static,
-				typeof(void), new[] { typeof(MsgPackSerializer), typeArray });
+        private static MethodInfo BuildSerializer(Type type, Type typeArray, TypeBuilder typeBuilder)
+        {
+            MethodBuilder methodSerialize = typeBuilder.DefineMethod("Serialize",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(void), new[] { typeof(MsgPackSerializer), typeArray });
 
-			var g = methodSerialize.GetILGenerator();
-			g.DeclareLocal(typeof(uint)); // length
-			g.DeclareLocal(typeof(uint)); // i
+            var g = methodSerialize.GetILGenerator();
+            g.DeclareLocal(typeof(uint)); // length
+            g.DeclareLocal(typeof(uint)); // i
 
-			// if (array == null) goto WriteNil()
-			Label nilWrite = g.DefineLabel();
-			g.Emit(OpCodes.Ldarg_1);
-			g.Emit(OpCodes.Ldnull);
-			g.Emit(OpCodes.Beq, nilWrite);
+            // if (array == null) goto WriteNil()
+            Label nilWrite = g.DefineLabel();
+            g.Emit(OpCodes.Ldarg_1);
+            g.Emit(OpCodes.Ldnull);
+            g.Emit(OpCodes.Beq, nilWrite);
 
-			// length = array.Length
-			g.Emit(OpCodes.Ldarg_1);
-			g.Emit(OpCodes.Ldlen);
-			g.Emit(OpCodes.Stloc_0);
+            // length = array.Length
+            g.Emit(OpCodes.Ldarg_1);
+            if (typeArray.IsArray)
+                g.Emit(OpCodes.Ldlen);
+            else
+                g.EmitCall(OpCodes.Callvirt, typeArray.GetProperty("Count")?.GetGetMethod(), null);
+            g.Emit(OpCodes.Stloc_0);
 
-			// write header
-			g.Emit(OpCodes.Ldarg_0);
-			g.Emit(OpCodes.Ldloc_0);
-			g.EmitCall(OpCodes.Call, GetVoidMethod<uint>(WriteArrayHeader), null);
+            // write header
+            g.Emit(OpCodes.Ldarg_0);
+            g.Emit(OpCodes.Ldloc_0);
+            g.EmitCall(OpCodes.Call, GetVoidMethod<uint>(WriteArrayHeader), null);
 
-			// i = 0
-			g.Emit(OpCodes.Ldc_I4_0);
-			g.Emit(OpCodes.Stloc_1);
+            // i = 0
+            g.Emit(OpCodes.Ldc_I4_0);
+            g.Emit(OpCodes.Stloc_1);
 
-			// for (uint i = 0; i < length; ++i)
-			{
-				Label whileCond = g.DefineLabel();
-				Label whileLoop = g.DefineLabel();
-				g.Emit(OpCodes.Br_S, whileCond);
-				g.MarkLabel(whileLoop);
+            // for (uint i = 0; i < length; ++i)
+            {
+                Label whileCond = g.DefineLabel();
+                Label whileLoop = g.DefineLabel();
+                g.Emit(OpCodes.Br_S, whileCond);
+                g.MarkLabel(whileLoop);
 
-				// serialize value
-				g.Emit(OpCodes.Ldarg_0);
-				g.Emit(OpCodes.Ldarg_1);
+                // serialize value
+                g.Emit(OpCodes.Ldarg_0);
+                g.Emit(OpCodes.Ldarg_1);
 
-				if (typeArray.IsArray)
-				{
-					g.Emit(OpCodes.Ldloc_1);
-					g.Emit(OpCodes.Ldelem, type);
-				}
-				else
-					g.EmitCall(OpCodes.Call, typeArray.GetMethod("get_Item"), null);
+                if (typeArray.IsArray)
+                {
+                    g.Emit(OpCodes.Ldloc_1);
+                    g.Emit(OpCodes.Ldelem, type);
+                }
+                else
+                {
+                    var getter = typeArray.GetProperty("Item").GetGetMethod();
+                    g.Emit(OpCodes.Ldloc_1);
+                    g.EmitCall(OpCodes.Callvirt, getter, null);
+                }
 
-				g.EmitCall(OpCodes.Call, MsgPackRegistry.GetOrCreateSerializer(type), null);
+                g.EmitCall(OpCodes.Call, MsgPackRegistry.GetOrCreateSerializer(type), null);
 
-				// ++i
-				g.Emit(OpCodes.Ldloc_1);
-				g.Emit(OpCodes.Ldc_I4_1);
-				g.Emit(OpCodes.Add);
-				g.Emit(OpCodes.Stloc_1);
+                // ++i
+                g.Emit(OpCodes.Ldloc_1);
+                g.Emit(OpCodes.Ldc_I4_1);
+                g.Emit(OpCodes.Add);
+                g.Emit(OpCodes.Stloc_1);
 
-				// i < length
-				g.MarkLabel(whileCond);
-				g.Emit(OpCodes.Ldloc_1);
-				g.Emit(OpCodes.Ldloc_0);
-				g.Emit(OpCodes.Blt_Un, whileLoop);
-			}
-			g.Emit(OpCodes.Ret);
+                // i < length
+                g.MarkLabel(whileCond);
+                g.Emit(OpCodes.Ldloc_1);
+                g.Emit(OpCodes.Ldloc_0);
+                g.Emit(OpCodes.Blt_Un, whileLoop);
+            }
+            g.Emit(OpCodes.Ret);
 
-			// write nil
-			g.MarkLabel(nilWrite);
-			g.Emit(OpCodes.Ldarg_0);
-			g.EmitCall(OpCodes.Call, GetVoidMethod(WriteNil), null);
-			g.Emit(OpCodes.Ret);
+            // write nil
+            g.MarkLabel(nilWrite);
+            g.Emit(OpCodes.Ldarg_0);
+            g.EmitCall(OpCodes.Call, GetVoidMethod(WriteNil), null);
+            g.Emit(OpCodes.Ret);
 
-			return methodSerialize;
-		}
+            return methodSerialize;
+        }
 
-		private static MethodInfo BuildDeserializer(Type type, Type typeArray, TypeBuilder typeBuilder)
-		{
-			MethodBuilder methodDeserialize = typeBuilder.DefineMethod("Deserialize",
-				MethodAttributes.Public | MethodAttributes.Static,
-				typeArray, new[] { typeof(MsgPackDeserializer).MakeByRefType() });
+        private static MethodInfo BuildDeserializer(Type type, Type typeArray, TypeBuilder typeBuilder)
+        {
+            MethodBuilder methodDeserialize = typeBuilder.DefineMethod("Deserialize",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeArray, new[] { typeof(MsgPackDeserializer).MakeByRefType() });
 
-			bool genericArray = !typeArray.IsArray;
+            bool genericArray = !typeArray.IsArray;
 
-			var g = methodDeserialize.GetILGenerator();
-			g.DeclareLocal(typeof(uint)); // type first size after
-			g.DeclareLocal(typeof(uint));
-			g.DeclareLocal(typeArray);
+            var g = methodDeserialize.GetILGenerator();
+            g.DeclareLocal(typeof(uint)); // type first size after
+            g.DeclareLocal(typeof(uint));
+            g.DeclareLocal(typeArray);
 
-			// get type
-			g.Emit(OpCodes.Ldarg_0);
-			g.EmitCall(OpCodes.Call, GetResultMethod(ReadByte), null);
-			g.Emit(OpCodes.Stloc_0);
+            // get type
+            g.Emit(OpCodes.Ldarg_0);
+            g.EmitCall(OpCodes.Call, GetResultMethod(ReadByte), null);
+            g.Emit(OpCodes.Stloc_0);
 
-			// if (array == null) return null
-			Label nilWrite = g.DefineLabel();
-			g.Emit(OpCodes.Ldloc_0);
-			g.Emit(OpCodes.Ldc_I4, (int)MsgPackCode.Nil);
-			g.Emit(OpCodes.Beq, nilWrite);
+            // if (array == null) return null
+            Label nilWrite = g.DefineLabel();
+            g.Emit(OpCodes.Ldloc_0);
+            g.Emit(OpCodes.Ldc_I4, (int)MsgPackCode.Nil);
+            g.Emit(OpCodes.Beq, nilWrite);
 
-			// get size and create array with the read size
-			g.Emit(OpCodes.Ldarg_0);
-			g.Emit(OpCodes.Ldloc_0);
-			g.EmitCall(OpCodes.Call, GetResultMethod<byte, uint>(ReadArraySize), null);
-			g.Emit(OpCodes.Stloc_0); // use loc_0 as size now
+            // get size and create array with the read size
+            g.Emit(OpCodes.Ldarg_0);
+            g.Emit(OpCodes.Ldloc_0);
+            g.EmitCall(OpCodes.Call, GetResultMethod<byte, uint>(ReadArraySize), null);
+            g.Emit(OpCodes.Stloc_0); // use loc_0 as size now
 
-			if (!genericArray)
-			{
-				// loc_2 = new T[loc_0];
-				g.Emit(OpCodes.Ldloc_0);
-				g.Emit(OpCodes.Newarr, typeArray);
-				g.Emit(OpCodes.Stloc_2);
-			}
-			else
-			{
-				// loc_2 = new List<T>(loc_0);
-				g.Emit(OpCodes.Ldloc_0);
-				g.Emit(OpCodes.Newobj, typeArray.GetConstructor(new[] { typeof(int) }));
-				g.Emit(OpCodes.Stloc_2);
-			}
+            if (!genericArray)
+            {
+                // loc_2 = new T[loc_0];
+                g.Emit(OpCodes.Ldloc_0);
+                g.Emit(OpCodes.Newarr, typeArray);
+                g.Emit(OpCodes.Stloc_2);
+            }
+            else
+            {
+                // loc_2 = new List<T>(loc_0);
+                g.Emit(OpCodes.Ldloc_0);
+                g.Emit(OpCodes.Newobj, typeArray.GetConstructor(new[] { typeof(int) }));
+                g.Emit(OpCodes.Stloc_2);
+            }
 
-			// i = 0
-			g.Emit(OpCodes.Ldc_I4_0);
-			g.Emit(OpCodes.Stloc_1);
+            // i = 0
+            g.Emit(OpCodes.Ldc_I4_0);
+            g.Emit(OpCodes.Stloc_1);
 
-			// for (uint i = 0; i < length; ++i)
-			{
-				Label whileCond = g.DefineLabel();
-				Label whileLoop = g.DefineLabel();
-				g.Emit(OpCodes.Br_S, whileCond);
-				g.MarkLabel(whileLoop);
+            // for (uint i = 0; i < length; ++i)
+            {
+                Label whileCond = g.DefineLabel();
+                Label whileLoop = g.DefineLabel();
+                g.Emit(OpCodes.Br_S, whileCond);
+                g.MarkLabel(whileLoop);
 
-				// array[loc_0] prestacking [ array, index, value ]
-				g.Emit(OpCodes.Ldloc_2);
+                // array[loc_0] prestacking [ array, index, value ]
+                g.Emit(OpCodes.Ldloc_2);
 
-				if (!genericArray)
-					g.Emit(OpCodes.Ldloc_1);
+                if (!genericArray)
+                    g.Emit(OpCodes.Ldloc_1);
 
-				// deserialize value
-				g.Emit(OpCodes.Ldarg_0);
-				g.EmitCall(OpCodes.Call, MsgPackRegistry.GetOrCreateDeserializer(type), null);
+                // deserialize value
+                g.Emit(OpCodes.Ldarg_0);
+                g.EmitCall(OpCodes.Call, MsgPackRegistry.GetOrCreateDeserializer(type), null);
 
-				if (!genericArray)
-					g.Emit(OpCodes.Stelem, type); // array[loc_0] = deserialized value
-				else
-					g.EmitCall(OpCodes.Call, typeArray.GetMethod("Add", new[] { type }), null);
+                if (!genericArray)
+                    g.Emit(OpCodes.Stelem, type); // array[loc_0] = deserialized value
+                else
+                    g.EmitCall(OpCodes.Callvirt, typeArray.GetMethod("Add", new[] { type }), null);
 
-				// ++i
-				g.Emit(OpCodes.Ldloc_1);
-				g.Emit(OpCodes.Ldc_I4_1);
-				g.Emit(OpCodes.Add);
-				g.Emit(OpCodes.Stloc_1);
+                // ++i
+                g.Emit(OpCodes.Ldloc_1);
+                g.Emit(OpCodes.Ldc_I4_1);
+                g.Emit(OpCodes.Add);
+                g.Emit(OpCodes.Stloc_1);
 
-				// i < length
-				g.MarkLabel(whileCond);
-				g.Emit(OpCodes.Ldloc_1);
-				g.Emit(OpCodes.Ldloc_0);
-				g.Emit(OpCodes.Blt_Un, whileLoop);
-			}
+                // i < length
+                g.MarkLabel(whileCond);
+                g.Emit(OpCodes.Ldloc_1);
+                g.Emit(OpCodes.Ldloc_0);
+                g.Emit(OpCodes.Blt_Un, whileLoop);
+            }
 
-			g.Emit(OpCodes.Ldloc_2);
-			g.Emit(OpCodes.Ret);
+            g.Emit(OpCodes.Ldloc_2);
+            g.Emit(OpCodes.Ret);
 
-			// return null
-			g.MarkLabel(nilWrite);
-			g.Emit(OpCodes.Ldnull);
-			g.Emit(OpCodes.Ret);
+            // return null
+            g.MarkLabel(nilWrite);
+            g.Emit(OpCodes.Ldnull);
+            g.Emit(OpCodes.Ret);
 
-			return methodDeserialize;
-		}
-	}
+            return methodDeserialize;
+        }
+    }
 }

--- a/MsgPack/Formatters/DictionaryFormatter.cs
+++ b/MsgPack/Formatters/DictionaryFormatter.cs
@@ -19,7 +19,7 @@ namespace CitizenFX.MsgPack.Formatters
 			Type typeIDictionary = typeof(IDictionary<,>).MakeGenericType(typeKey, typeValue);
 			Type typeIReadOnlyDictionary = typeof(IReadOnlyDictionary<,>).MakeGenericType(typeKey, typeValue);
 
-			string name = $"DictionaryFormatter[{typeKey.FullName}, {typeValue.FullName}]";
+			string name = $"DictionaryFormatter_{typeKey.FullName}_{typeValue.FullName}";
 			Type buildType = MsgPackRegistry.m_moduleBuilder.GetType(name);
 
 			if (buildType == null)

--- a/MsgPack/Formatters/DictionaryFormatter.cs
+++ b/MsgPack/Formatters/DictionaryFormatter.cs
@@ -19,7 +19,7 @@ namespace CitizenFX.MsgPack.Formatters
 			Type typeIDictionary = typeof(IDictionary<,>).MakeGenericType(typeKey, typeValue);
 			Type typeIReadOnlyDictionary = typeof(IReadOnlyDictionary<,>).MakeGenericType(typeKey, typeValue);
 
-			string name = $"DictionaryFormatter<{typeKey.FullName}, {typeValue.FullName}>";
+			string name = $"DictionaryFormatter[{typeKey.FullName}, {typeValue.FullName}]";
 			Type buildType = MsgPackRegistry.m_moduleBuilder.GetType(name);
 
 			if (buildType == null)

--- a/MsgPack/Formatters/TypeFormatter.cs
+++ b/MsgPack/Formatters/TypeFormatter.cs
@@ -68,7 +68,7 @@ namespace CitizenFX.MsgPack.Formatters
 
 			if (methodSerialize == null || methodDeserialize == null)
 			{
-				string name = $"TypeFormatter<{type.FullName}>";
+				string name = $"TypeFormatter_{type.FullName}";
 				Type buildType = MsgPackRegistry.m_moduleBuilder.GetType(name);
 
 				if (buildType == null)

--- a/MsgPack/MsgPackDeserializer.cs
+++ b/MsgPack/MsgPackDeserializer.cs
@@ -335,11 +335,11 @@ namespace CitizenFX.MsgPack
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal Callback ReadCallback(uint length)
 		{
-			var refFunc = ReadString(length);
+            var refFunc = ReadString(length);
 #if !MONO_V2 // we don't have mock ups of these on our MsgPack project
 			return null;
 #else
-			return m_netSource is null
+            return m_netSource is null
 				? _LocalFunction.Create(refFunc)
 #if REMOTE_FUNCTION_ENABLED
 				: _RemoteFunction.Create(refFunc, m_netSource);

--- a/MsgPack/MsgPackDeserializer.cs
+++ b/MsgPack/MsgPackDeserializer.cs
@@ -126,7 +126,7 @@ namespace CitizenFX.MsgPack
 		internal unsafe string ReadString(uint length)
 		{
 			sbyte* v = (sbyte*)AdvancePointer(length);
-			return new string(v, 0, (int)length);
+            return new string(v, 0, (int)length);
 		}
 
 		internal unsafe CString ReadCString(uint length)

--- a/MsgPack/MsgPackDeserializerConvert.cs
+++ b/MsgPack/MsgPackDeserializerConvert.cs
@@ -621,11 +621,28 @@ namespace CitizenFX.MsgPack
 			return array;
 		}
 
-		#endregion
+		public byte[] DeserializeByteArray()
+		{
+			MsgPackCode type = (MsgPackCode)ReadByte();
+			switch (type)
+			{
+                case MsgPackCode.Bin8: return ReadBytes(ReadUInt8());
+                case MsgPackCode.Bin16: return ReadBytes(ReadUInt16());
+                case MsgPackCode.Bin32: return ReadBytes(ReadUInt32());
+            }
+			throw new InvalidOperationException($"Tried to decode invalid MsgPack type {type}");
+        }
 
-		#region Extra types
+		public List<byte> DeserializeAsByteList()
+		{
+            return new List<byte>(DeserializeByteArray());
+        }
 
-		public Callback DeserializeAsCallback()
+        #endregion
+
+        #region Extra types
+
+        public Callback DeserializeAsCallback()
 		{
 
 			byte type = ReadByte();
@@ -670,6 +687,8 @@ namespace CitizenFX.MsgPack
         public static uint DeserializeAsUInt32(ref MsgPackDeserializer deserializer) => deserializer.DeserializeAsUInt32();
 		public static string DeserializeAsString(ref MsgPackDeserializer deserializer) => deserializer.DeserializeAsString();
 		public static string[] DeserializeAsStringArray(ref MsgPackDeserializer deserializer) => deserializer.DeserializeAsStringArray();
+		public static byte[] DeserializeByteArray(ref MsgPackDeserializer deserializer) => deserializer.DeserializeByteArray();
+		public static List<byte> DeserializeAsByteList(ref MsgPackDeserializer deserializer) => deserializer.DeserializeAsByteList();
 
         #endregion
     }

--- a/MsgPack/MsgPackDeserializerConvert.cs
+++ b/MsgPack/MsgPackDeserializerConvert.cs
@@ -511,7 +511,7 @@ namespace CitizenFX.MsgPack
 		public string DeserializeAsString()
 		{
 			MsgPackCode type = (MsgPackCode)ReadByte();
-			if (type <= MsgPackCode.FixStrMax)
+            if (type <= MsgPackCode.FixStrMax)
 			{
 				if (type <= MsgPackCode.FixIntPositiveMax)
 					return ((byte)type).ToString();

--- a/MsgPack/MsgPackDeserializerConvert.cs
+++ b/MsgPack/MsgPackDeserializerConvert.cs
@@ -627,40 +627,52 @@ namespace CitizenFX.MsgPack
 
 		public Callback DeserializeAsCallback()
 		{
-			MsgPackCode type = ReadType();
-			switch (type)
-			{
-				case MsgPackCode.Ext8: SkipBytes(1); goto case MsgPackCode.FixExt16;
-				case MsgPackCode.Ext16: SkipBytes(2); goto case MsgPackCode.FixExt16;
-				case MsgPackCode.Ext32: SkipBytes(4); goto case MsgPackCode.FixExt16;
 
-				case MsgPackCode.FixExt1: // 1
-				case MsgPackCode.FixExt2: // 2
-				case MsgPackCode.FixExt4: // 4
-				case MsgPackCode.FixExt8: // 8
-				case MsgPackCode.FixExt16: // 16
-					{
-						var extType = ReadByte();
-						return extType == 10 || extType == 11
-							? ReadCallback(ReadUInt8())
-							: throw new InvalidCastException($"MsgPack extra type {extType} could not be deserialized into type {typeof(Callback)}");
-					}
-			}
+			byte type = ReadByte();
+            uint length = 0;
+            switch (type)
+            {
+                case 0xC7:
+                    length = ReadUInt8();
+                    break;
+                case 0xC8:
+                    length = ReadUInt16();
+                    break;
+                case 0xC9:
+                    length = ReadUInt32();
+                    break;
+                case 0xD4:
+                    length = 1;
+                    break;
+                case 0xD5:
+                    length = 2;
+                    break;
+                case 0xD6:
+                    length = 4;
+                    break;
+                case 0xD7:
+                    length = 8;
+                    break;
+                case 0xD8:
+                    length = 16;
+                    break;
+            }
+            var extType = ReadByte();
+            return extType == 10 || extType == 11
+                ? ReadCallback(length)
+                : throw new InvalidCastException($"MsgPack extra type {extType} could not be deserialized into type {typeof(Callback)}");
+        }
 
-			SkipObject(type);
-			throw new InvalidCastException($"MsgPack type {type} could not be deserialized into type {typeof(Callback)}");
-		}
+        #endregion
 
-		#endregion
+        #region Statics (easier access with current IL generation)
 
-		#region Statics (easier access with current IL generation)
-
-		public static uint DeserializeAsUInt32(ref MsgPackDeserializer deserializer) => deserializer.DeserializeAsUInt32();
+        public static uint DeserializeAsUInt32(ref MsgPackDeserializer deserializer) => deserializer.DeserializeAsUInt32();
 		public static string DeserializeAsString(ref MsgPackDeserializer deserializer) => deserializer.DeserializeAsString();
 		public static string[] DeserializeAsStringArray(ref MsgPackDeserializer deserializer) => deserializer.DeserializeAsStringArray();
 
-		#endregion
-	}
+        #endregion
+    }
 }
 
 #pragma warning restore IDE0004 // Remove unnecessary cast

--- a/MsgPack/MsgPackFunc.cs
+++ b/MsgPack/MsgPackFunc.cs
@@ -339,7 +339,21 @@ namespace CitizenFX.MsgPack
 					g.Emit(ldarg_deserializer);
 					g.Emit(OpCodes.Call, GetResultMethod<string[]>(DeserializeAsStringArray));
 				}
-				else if (t == typeof(string) || t == typeof(object)) // raw data; simply pass it on
+				else if (t == typeof(byte[]))
+				{
+                    ++p;
+
+                    g.Emit(ldarg_deserializer);
+                    g.Emit(OpCodes.Call, GetResultMethod<byte[]>(DeserializeByteArray));
+                }
+                else if (t == typeof(List<byte>))
+                {
+                    ++p;
+
+                    g.Emit(ldarg_deserializer);
+                    g.Emit(OpCodes.Call, GetResultMethod<List<byte>>(DeserializeAsByteList));
+                }
+                else if (t == typeof(string) || t == typeof(object)) // raw data; simply pass it on
 				{
 					if (p == 1)
 					{

--- a/MsgPack/MsgPackReferenceRegistrar.cs
+++ b/MsgPack/MsgPackReferenceRegistrar.cs
@@ -1,0 +1,22 @@
+﻿using CitizenFX.MsgPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CitizenFX.MsgPack
+{
+    public static class MsgPackReferenceRegistrar
+    {
+        public static Func<MsgPackFunc, KeyValuePair<int, byte[]>> CreateFunc { get; set; }
+
+        public static KeyValuePair<int, byte[]> Register(MsgPackFunc func)
+        {
+            if (CreateFunc == null)
+                throw new InvalidOperationException("Reference function not registered");
+
+            return CreateFunc(func);
+        }
+    }
+}

--- a/MsgPack/MsgPackRegistry.cs
+++ b/MsgPack/MsgPackRegistry.cs
@@ -139,6 +139,20 @@ namespace CitizenFX.MsgPack
                     // add remote function delegate support ? - don't think if it's even planned or supported
                     serializer.Serialize(del);
                 }
+                // byte[] is a special type handled like a Binary object. 
+                // It is not a primitive type, so i serialized as a binary object and deserialized as such.
+                else if (obj is byte[] b)
+				{
+					serializer.Serialize(b);
+				}
+                // same applies to List<byte>
+				// we serialize it as a byte array and deserialize it as such
+				// it's not elegant but i needed to handle it like this as byte is a binary format even in List
+				// Ps: Who the fuck in fivem would retrieve and send List<byte>??????
+                else if (obj is List<byte> lb)
+                {
+                    serializer.Serialize(lb.ToArray());
+                }
                 else if (TryGetSerializer(type, out var methodInfo))
 				{
 					methodInfo.m_objectSerializer(serializer, obj);
@@ -176,7 +190,7 @@ namespace CitizenFX.MsgPack
 
 		internal static MethodInfo GetOrCreateDeserializer(Type type)
 		{
-			return TryGetDeserializer(type, out var methodInfo)
+            return TryGetDeserializer(type, out var methodInfo)
 				? methodInfo
 				: CreateSerializer(type)?.Item2;
 		}
@@ -192,7 +206,7 @@ namespace CitizenFX.MsgPack
 			}
 			else if (type.IsArray)
 			{
-				switch (type.GetArrayRank())
+                switch (type.GetArrayRank())
 				{
 					case 1:
 						return ArrayFormatter.Build(type.GetElementType(), type);
@@ -205,7 +219,7 @@ namespace CitizenFX.MsgPack
 				{
 					case 1:
 						{
-							if (ImplementsGenericTypeDefinition(type, typeof(IEnumerable<>)))
+							if (ImplementsGenericTypeDefinition(type, typeof(List<>)))
 								return ArrayFormatter.Build(genericTypes[0], type);
 						}
 						break;

--- a/MsgPack/MsgPackSerializer.cs
+++ b/MsgPack/MsgPackSerializer.cs
@@ -109,9 +109,9 @@ namespace CitizenFX.MsgPack
 		{
             // this works only if msgpack lib is built within fivem, it's not really elegant imho
             // but it works, so let's not break it now, shall we?
-            // TODO: Make this work without depending from ReferenceFunctionManager and make our own
-            // Canonicalization of the reference id
-			// TODO: Add support for by 10 (Remote Delegate)
+            // TODO: Make this work without depending from ReferenceFunctionManager
+			// and make our own Canonicalization of the reference id
+			// TODO: Add support for byte 10 (Remote Delegate)? don't think it's enabled in FiveM currently
             var remote = ReferenceFunctionManager.Create(MsgPackDeserializer.CreateDelegate(d));
             uint size = (uint)remote.Value.LongLength;
             EnsureCapacity((uint)remote .Value.Length);

--- a/MsgPack/MsgPackSerializer.cs
+++ b/MsgPack/MsgPackSerializer.cs
@@ -126,7 +126,7 @@ namespace CitizenFX.MsgPack
 			Array.Copy(bytes, 0, m_buffer, (int)m_position, size);
 			m_position += size;
 #else
-            var remote = ReferenceFunctionManager.Create(MsgPackDeserializer.CreateDelegate(d));
+            var remote = MsgPackReferenceRegistrar.Register(MsgPackDeserializer.CreateDelegate(d));
 			uint size = (uint)remote.Value.LongLength;
 			EnsureCapacity((uint)remote.Value.Length);
 			WriteExtraTypeHeader(size);


### PR DESCRIPTION
This PR introduces several important improvements and fixes to the MsgPack serialization library:

- Added support for delegates serialization (fixes https://github.com/citizenfx/fivem/issues/2653, https://github.com/citizenfx/fivem/issues/2590, https://github.com/citizenfx/fivem/issues/2582).
- Fixed serialization issues with Lists, ensuring correct handling of collections.
- Corrected string serialization when the string length exceeds 256 bytes (fixes https://github.com/citizenfx/fivem/issues/2613).
- Improved handling of special cases for byte[] and List<byte>, treating them appropriately as binary data (fixes https://github.com/citizenfx/fivem/issues/2571).
- Fixed naming conventions to avoid unsupported characters such as <>.

These changes enhance the robustness and compatibility of the MsgPack formatter, especially when working with complex data types.

