### PR TITLE
feat(vendor/msgpack): added `GetMethodInfoFromDelegate` to allow getting correct MethodInfo from exception

### DIFF
--- a/MsgPack/MsgPackFunc.cs
+++ b/MsgPack/MsgPackFunc.cs
@@ -51,6 +51,16 @@ namespace CitizenFX.MsgPack
 		// no need to recreate it
 		public static MsgPackFunc CreateDelegate(MsgPackFunc deleg) => deleg;
 
+		public static MethodInfo GetMethodInfoFromDelegate(MsgPackFunc func)
+		{
+			foreach (var kvp in s_wrappedMethods)
+			{
+				if (kvp.Value == func.Method)
+					return kvp.Key;
+			}
+			return null;
+		}
+
 		[SecurityCritical]
 		private static MsgPackFunc ConstructDelegate(object target, MethodInfo method)
 		{


### PR DESCRIPTION
## **Goal of this PR**

Allows WriteException method to retrieve the correct method info to show in exception message for erroring events / exports