### PR TITLE
fix(vendor/msgpack-cs): fix formatter struct serialization and added Enum formatter

### DIFF
--- a/MsgPack/Formatters/EnumFormatter.cs
+++ b/MsgPack/Formatters/EnumFormatter.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace CitizenFX.MsgPack.Formatters
+{
+	internal static class EnumFormatter
+	{
+		public static Tuple<Serializer, MethodInfo> Build(Type enumType, Type unused = null)
+		{
+			string name = $"EnumFormatter_{enumType.FullName}";
+			Type buildType = MsgPackRegistry.m_moduleBuilder.GetType(name);
+
+			MethodInfo methodSerialize, methodDeserialize, methodObjectSerialize;
+
+			if (buildType == null)
+			{
+				TypeBuilder typeBuilder = MsgPackRegistry.m_moduleBuilder.DefineType(name);
+
+				methodSerialize = BuildSerializer(enumType, typeBuilder);
+				BuildDeserializer(enumType, typeBuilder);
+				BuildObjectSerializer(enumType, methodSerialize, typeBuilder);
+
+				buildType = typeBuilder.CreateType();
+			}
+
+			methodSerialize = buildType.GetMethod("Serialize", new[] { typeof(MsgPackSerializer), enumType });
+			methodDeserialize = buildType.GetMethod("Deserialize");
+			methodObjectSerialize = buildType.GetMethod("Serialize", new[] { typeof(MsgPackSerializer), typeof(object) });
+
+			Serializer serializer = new Serializer(methodSerialize, methodObjectSerialize);
+
+			MsgPackRegistry.RegisterSerializer(enumType, serializer);
+			MsgPackRegistry.RegisterDeserializer(enumType, methodDeserialize);
+
+			return new Tuple<Serializer, MethodInfo>(serializer, methodDeserialize);
+		}
+
+		private static MethodInfo BuildObjectSerializer(Type enumType, MethodInfo methodSerialize, TypeBuilder typeBuilder)
+		{
+			MethodBuilder method = typeBuilder.DefineMethod("Serialize",
+				MethodAttributes.Public | MethodAttributes.Static,
+				typeof(void),
+				new[] { typeof(MsgPackSerializer), typeof(object) });
+
+			var g = method.GetILGenerator();
+			g.Emit(OpCodes.Ldarg_0);
+			g.Emit(OpCodes.Ldarg_1);
+			g.Emit(OpCodes.Unbox_Any, enumType);
+			g.EmitCall(OpCodes.Call, methodSerialize, null);
+			g.Emit(OpCodes.Ret);
+
+			return method;
+		}
+
+		private static MethodInfo BuildSerializer(Type enumType, TypeBuilder typeBuilder)
+		{
+			MethodBuilder method = typeBuilder.DefineMethod("Serialize",
+				MethodAttributes.Public | MethodAttributes.Static,
+				typeof(void),
+				new[] { typeof(MsgPackSerializer), enumType });
+
+			var g = method.GetILGenerator();
+			g.Emit(OpCodes.Ldarg_0);
+			g.Emit(OpCodes.Ldarg_1);
+			g.EmitCall(OpCodes.Call, MsgPackRegistry.GetOrCreateSerializer(typeof(uint)), null);
+			g.Emit(OpCodes.Ret);
+			return method;
+		}
+
+		private static MethodInfo BuildDeserializer(Type enumType, TypeBuilder typeBuilder)
+		{
+			MethodBuilder methodDeserialize = typeBuilder.DefineMethod("Deserialize",
+				MethodAttributes.Public | MethodAttributes.Static,
+				enumType, new[] { typeof(MsgPackDeserializer).MakeByRefType() });
+			var g = methodDeserialize.GetILGenerator();
+			g.Emit(OpCodes.Ldarg_0);
+			g.EmitCall(OpCodes.Call, MsgPackRegistry.GetOrCreateDeserializer(typeof(uint)), null);
+			g.Emit(OpCodes.Ret);
+			return methodDeserialize;
+		}
+	}
+}

--- a/MsgPack/Formatters/TypeFormatter.cs
+++ b/MsgPack/Formatters/TypeFormatter.cs
@@ -230,15 +230,11 @@ namespace CitizenFX.MsgPack.Formatters
 							// if it's a struct.. we handle it differently
 							// using the address of the argument and not its value.
 							if (type.IsValueType)
-							{
 								g.Emit(OpCodes.Ldarga_S, 1);
-								g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
-							}
 							else
-							{
 								g.Emit(OpCodes.Ldarg_1);
-								g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
-							}
+
+							g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
 							g.EmitCall(OpCodes.Call, serializer, null);
 						}
 						break;
@@ -318,15 +314,11 @@ namespace CitizenFX.MsgPack.Formatters
 							// if it's a struct.. we handle it differently
 							// using the address of the argument and not its value.
 							if (type.IsValueType)
-							{
 								g.Emit(OpCodes.Ldarga_S, 1);
-								g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
-							}
 							else
-							{
 								g.Emit(OpCodes.Ldarg_1);
-								g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
-							}
+
+							g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
 							g.EmitCall(OpCodes.Call, methodPropertySerializer, null);
 						}
 						break;

--- a/MsgPack/Formatters/TypeFormatter.cs
+++ b/MsgPack/Formatters/TypeFormatter.cs
@@ -227,8 +227,18 @@ namespace CitizenFX.MsgPack.Formatters
 
 							// Value
 							g.Emit(OpCodes.Ldarg_0);
-							g.Emit(OpCodes.Ldarg_1);
-							g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
+							// if it's a struct.. we handle it differently
+							// using the address of the argument and not its value.
+							if (type.IsValueType)
+							{
+								g.Emit(OpCodes.Ldarga_S, 1);
+								g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
+							}
+							else
+							{
+								g.Emit(OpCodes.Ldarg_1);
+								g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
+							}
 							g.EmitCall(OpCodes.Call, serializer, null);
 						}
 						break;
@@ -290,11 +300,11 @@ namespace CitizenFX.MsgPack.Formatters
 
 					case PropertyInfo property:
 						{
-							var methodFieldSerializer = type == property.PropertyType
+							var methodPropertySerializer = type == property.PropertyType
 								? currentSerializer
 								: MsgPackRegistry.GetOrCreateSerializer(property.PropertyType);
 
-							if (methodFieldSerializer == null)
+							if (methodPropertySerializer == null)
 								throw new NotSupportedException($"Requested serializer for {type.Name}.{property.Name} of type {property.PropertyType} could not be found.");
 
 							// Key
@@ -304,9 +314,20 @@ namespace CitizenFX.MsgPack.Formatters
 
 							// Value
 							g.Emit(OpCodes.Ldarg_0);
-							g.Emit(OpCodes.Ldarg_1);
-							g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
-							g.EmitCall(OpCodes.Call, methodFieldSerializer, null);
+							// Same as above
+							// if it's a struct.. we handle it differently
+							// using the address of the argument and not its value.
+							if (type.IsValueType)
+							{
+								g.Emit(OpCodes.Ldarga_S, 1);
+								g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
+							}
+							else
+							{
+								g.Emit(OpCodes.Ldarg_1);
+								g.EmitCall(OpCodes.Call, property.GetGetMethod(), null);
+							}
+							g.EmitCall(OpCodes.Call, methodPropertySerializer, null);
 						}
 						break;
 

--- a/MsgPack/MsgPackRegistry.cs
+++ b/MsgPack/MsgPackRegistry.cs
@@ -146,6 +146,10 @@ namespace CitizenFX.MsgPack
 				{
 					serializer.Serialize(e);
 				}
+				else if (type.IsEnum)
+				{
+					serializer.Serialize(Convert.ToUInt64(obj));
+				}
 #endif
 				else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
 				{
@@ -227,6 +231,10 @@ namespace CitizenFX.MsgPack
 					return new Tuple<Serializer, MethodInfo>(m_serializers[type], m_serializers[type].m_method);
 				else
 					throw new NotSupportedException($"{type} should've already been registered");
+			}
+			else if (type.IsEnum)
+			{
+				return EnumFormatter.Build(type);
 			}
 			else if (type.IsArray)
 			{


### PR DESCRIPTION
## **GOAL OF THIS PR**
This fix addresses a bug in struct serialization where its parameters were being addressed as values and not as references generating a IL exception.

**NOTE:** this fix works only server-side, as long as client-side uses the previously added patch. Once that client-side will be allowed to use formatters this patch will automatically apply.

- Before:
![image](https://github.com/user-attachments/assets/d9ef6720-24af-4e83-a98a-38a1dfacc4b7)

- After:
![image](https://github.com/user-attachments/assets/dc446da1-2301-43ab-b197-9a455b079f5b)

------

__Edit 2025-06-18__: Added a dedicated formatter for enums to fix a rare edge case where enum fields inside structs were incorrectly serialized as structs themselves instead of their enum type. This also ensures correct handling of enums marked with the [Flags] attribute.


![image](https://github.com/user-attachments/assets/649ae175-87dd-4081-b561-0623dbaef3c2)

![image](https://github.com/user-attachments/assets/faa534ee-649a-4a38-ae4b-ad2078aa5bbf)
